### PR TITLE
Set QtQuick Controls 2 style using QQuickStyle

### DIFF
--- a/liri-calculator.pro
+++ b/liri-calculator.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = liri-calculator
 
 CONFIG += c++11
-QT += qml quick svg
+QT += qml quick svg quickcontrols2
 
 ICON += src/icons/liri-calculator.icns
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -24,12 +24,13 @@
 #include <QtGlobal>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <QtQuickControls2/QQuickStyle>
 #include <QDebug>
 
 int main(int argc, char *argv[])
 {
     // Set Material Design QtQuick Controls 2 style
-    qputenv("QT_QUICK_CONTROLS_STYLE", "material");
+    QQuickStyle::setStyle(QLatin1String("Material"));
 
     #if defined(ENABLE_HIGH_DPI_SCALING)
         QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);


### PR DESCRIPTION
The `QT_QUICK_CONTROLS_STYLE` environment variable is not meant
for QtQuick Controls 2 as of Qt 5.8-rc (see https://bugreports.qt.io/browse/QTBUG-52936).
Also see https://github.com/lirios/browser/issues/29.
Thanks to @plfiorini.